### PR TITLE
Disables the ore + calcite/lime recipes in the EBF

### DIFF
--- a/src/main/java/gregtech/loaders/oreprocessing/ProcessingOre.java
+++ b/src/main/java/gregtech/loaders/oreprocessing/ProcessingOre.java
@@ -86,13 +86,16 @@ public class ProcessingOre implements gregtech.api.interfaces.IOreRecipeRegistra
                 tHasSmelting = GT_ModHandler.addSmeltingRecipe(aOreStack, GT_Utility.copyAmount(aMultiplier * aMaterial.mSmeltingMultiplier, new Object[]{tSmeltInto}));
             }
 
-            if (aMaterial.contains(SubTag.BLASTFURNACE_CALCITE_TRIPLE)) {
+            // Modified by ChubbyTurtle101 and requested by Bear989
+            // Disables the ore plus calcite/Quicklime recipes in the Electric Blast Furnace.  New oreDust with calcite recipes are added to MachineRecipeLoader.java file.
+            // Almost all of these ore blocks are not available in BDE packs
+            /*if (aMaterial.contains(SubTag.BLASTFURNACE_CALCITE_TRIPLE)) {
                 GT_Values.RA.addBlastRecipe(aOreStack, GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Calcite,   aMultiplier), null, null, GT_Utility.mul(aMultiplier * 3 * aMaterial.mSmeltingMultiplier, new Object[]{tSmeltInto}), ItemList.TE_Slag.get(1L, new Object[]{GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.DarkAsh, 1L)}), tSmeltInto.stackSize * 500, 120, 1500);
                 GT_Values.RA.addBlastRecipe(aOreStack, GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Quicklime, aMultiplier), null, null, GT_Utility.mul(aMultiplier * 3 * aMaterial.mSmeltingMultiplier, new Object[]{tSmeltInto}), ItemList.TE_Slag.get(1L, new Object[]{GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.DarkAsh, 1L)}), tSmeltInto.stackSize * 500, 120, 1500);
             } else if (aMaterial.contains(SubTag.BLASTFURNACE_CALCITE_DOUBLE)) {
                 GT_Values.RA.addBlastRecipe(aOreStack, GT_OreDictUnificator.get(OrePrefixes.dust, Materials.Calcite, aMultiplier), null, null, GT_Utility.mul(aMultiplier * (GT_Mod.gregtechproxy.mMixedOreOnlyYieldsTwoThirdsOfPureOre ? 2 : 3) * aMaterial.mSmeltingMultiplier, new Object[]{tSmeltInto}), ItemList.TE_Slag.get(1L, new Object[]{GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.DarkAsh, 1L)}), tSmeltInto.stackSize * 500, 120, 1500);
                 GT_Values.RA.addBlastRecipe(aOreStack, GT_OreDictUnificator.get(OrePrefixes.dustTiny, Materials.Quicklime, aMultiplier * 3), null, null, GT_Utility.mul(aMultiplier * 2 * aMaterial.mSmeltingMultiplier, new Object[]{tSmeltInto}), ItemList.TE_Slag.get(1L, new Object[]{GT_OreDictUnificator.get(OrePrefixes.dustSmall, Materials.DarkAsh, 1L)}), tSmeltInto.stackSize * 500, 120, 1500);
-            }
+            }*/ 
         }
 
         if (!tHasSmelting) {


### PR DESCRIPTION
Removes all of the ore + calcite and ore + lime recipes in the electric blast furnace.  Most ores are not available in any BDE packs. 