### PR TITLE
Disabled GT5 flint tools if GT6 is loaded

### DIFF
--- a/src/main/java/gregtech/GT_Mod.java
+++ b/src/main/java/gregtech/GT_Mod.java
@@ -217,7 +217,8 @@ public class GT_Mod implements IGT_Mod {
             }
         }
         gregtechproxy.mMaxEqualEntitiesAtOneSpot = tMainConfig.get(aTextGeneral, "MaxEqualEntitiesAtOneSpot", 3).getInt(3);
-        gregtechproxy.mSkeletonsShootGTArrows = tMainConfig.get(aTextGeneral, "SkeletonsShootGTArrows", 16).getInt(16);
+        // Chubby Turtle change config to turn off GT arrows from 16 to 0
+        gregtechproxy.mSkeletonsShootGTArrows = tMainConfig.get(aTextGeneral, "SkeletonsShootGTArrows", 0).getInt(0);
         gregtechproxy.mFlintChance = tMainConfig.get(aTextGeneral, "FlintAndSteelChance", 30).getInt(30);
         gregtechproxy.mItemDespawnTime = tMainConfig.get(aTextGeneral, "ItemDespawnTime", 6000).getInt(6000);
         gregtechproxy.mNerfStorageBlocks = tMainConfig.get(aTextGeneral,"NerfStorageBlocks",true).getBoolean(true);
@@ -279,7 +280,8 @@ public class GT_Mod implements IGT_Mod {
         gregtechproxy.mEasierIVPlusCables = tMainConfig.get("general", "EasierIVPlusCables", false).getBoolean(false);
         gregtechproxy.mBrickedBlastFurnace = tMainConfig.get("general", "BrickedBlastFurnace", true).getBoolean(true);
         //gregtechproxy.mMixedOreOnlyYieldsTwoThirdsOfPureOre = tMainConfig.get("general", "MixedOreOnlyYieldsTwoThirdsOfPureOre", false).getBoolean(false);
-        gregtechproxy.mUseBandedIronAsHematiteCalcite = tMainConfig.get("general", "UseBandedIronAsHematiteCalcite", false).getBoolean(false);
+        gregtechproxy.mUseBandedIronAsHematiteCalcite = tMainConfig.get("general", "UseBandedIronAsHematiteCalcite", true).getBoolean(true);
+        gregtechproxy.mBlastFurnaceIronRecipes = tMainConfig.get("general", "AllowBlastFurnaceIronRecipes", true).getBoolean(true);
         gregtechproxy.mUseGT6Recipes = tMainConfig.get("general", "UseGT6Recipes", false).getBoolean(false);
         gregtechproxy.enableBlackGraniteOres = GregTech_API.sWorldgenFile.get("general", "enableBlackGraniteOres", gregtechproxy.enableBlackGraniteOres);
         gregtechproxy.enableRedGraniteOres = GregTech_API.sWorldgenFile.get("general", "enableRedGraniteOres", gregtechproxy.enableRedGraniteOres);

--- a/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Frame.java
+++ b/src/main/java/gregtech/api/metatileentity/implementations/GT_MetaPipeEntity_Frame.java
@@ -22,7 +22,8 @@ public class GT_MetaPipeEntity_Frame extends MetaPipeEntity {
         mMaterial = aMaterial;
 
         GT_OreDictUnificator.registerOre(OrePrefixes.frameGt, aMaterial, getStackForm(1));
-        GT_ModHandler.addCraftingRecipe(getStackForm(2), RecipeBits.NOT_REMOVABLE | GT_ModHandler.RecipeBits.BUFFERED, new Object[]{"SSS", "SwS", "SSS", 'S', OrePrefixes.stick.get(mMaterial)});
+        // Disable the hand crafting recipe as not needed and conflicts with GT6 recipes
+        //GT_ModHandler.addCraftingRecipe(getStackForm(2), RecipeBits.NOT_REMOVABLE | GT_ModHandler.RecipeBits.BUFFERED, new Object[]{"SSS", "SwS", "SSS", 'S', OrePrefixes.stick.get(mMaterial)});
         RA.addAssemblerRecipe(GT_OreDictUnificator.get(OrePrefixes.stick, aMaterial, 4), ItemList.Circuit_Integrated.getWithDamage(0, 4), getStackForm(1), 64, 8);
     }
 

--- a/src/main/java/gregtech/common/GT_Proxy.java
+++ b/src/main/java/gregtech/common/GT_Proxy.java
@@ -169,7 +169,7 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler {
     public boolean mHideRecyclingRecipes = true;
     public boolean mPollution = true;
     public boolean mExplosionItemDrop = false;
-    public int mSkeletonsShootGTArrows = 16;
+    public int mSkeletonsShootGTArrows = 0;
     public int mMaxEqualEntitiesAtOneSpot = 3;
     public int mFlintChance = 30;
     public int mItemDespawnTime = 6000;
@@ -205,7 +205,8 @@ public abstract class GT_Proxy implements IGT_Mod, IGuiHandler, IFuelHandler {
     public boolean mEasierIVPlusCables = false;
     public boolean mBrickedBlastFurnace = true;
     //public boolean mMixedOreOnlyYieldsTwoThirdsOfPureOre = false;
-    public boolean mUseBandedIronAsHematiteCalcite = false;
+    public boolean mUseBandedIronAsHematiteCalcite = true;
+    public boolean mBlastFurnaceIronRecipes = true;
     public boolean mUseGT6Recipes = false;
     public boolean enableBlackGraniteOres = true;
     public boolean enableRedGraniteOres = true;

--- a/src/main/java/gregtech/common/items/GT_MetaGenerated_Tool_01.java
+++ b/src/main/java/gregtech/common/items/GT_MetaGenerated_Tool_01.java
@@ -1,5 +1,6 @@
 package gregtech.common.items;
 
+import cpw.mods.fml.common.Loader;
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.*;
 import gregtech.api.items.GT_MetaGenerated_Tool;
@@ -121,7 +122,7 @@ public class GT_MetaGenerated_Tool_01 extends GT_MetaGenerated_Tool {
         GT_ModHandler.addCraftingRecipe(INSTANCE.getToolWithStats(ROLLING_PIN, 1, Materials.StainlessSteel, Materials.StainlessSteel, null), GT_ModHandler.RecipeBits.NOT_REMOVABLE, new Object[]{"  S", " I ", "S f", 'I', OrePrefixes.ingot.get(Materials.StainlessSteel), 'S', OrePrefixes.stick.get(Materials.StainlessSteel)});
 
 
-        if (!GregTech_API.sSpecialFile.get(ConfigCategories.general, "DisableFlintTools", false)) {
+        if (!GregTech_API.sSpecialFile.get(ConfigCategories.general, "DisableFlintTools", false) && !Loader.isModLoaded("gregtech")) {
             GT_ModHandler.addCraftingRecipe(INSTANCE.getToolWithStats(SWORD, 1, Materials.Flint, Materials.Wood, null), GT_ModHandler.RecipeBits.NOT_REMOVABLE, new Object[]{"F", "F", "S", 'S', OrePrefixes.stick.get(Materials.Wood), 'F', new ItemStack(Items.flint, 1)});
             GT_ModHandler.addCraftingRecipe(INSTANCE.getToolWithStats(PICKAXE, 1, Materials.Flint, Materials.Wood, null), GT_ModHandler.RecipeBits.NOT_REMOVABLE, new Object[]{"FFF", " S ", " S ", 'S', OrePrefixes.stick.get(Materials.Wood), 'F', new ItemStack(Items.flint, 1)});
             GT_ModHandler.addCraftingRecipe(INSTANCE.getToolWithStats(SHOVEL, 1, Materials.Flint, Materials.Wood, null), GT_ModHandler.RecipeBits.NOT_REMOVABLE, new Object[]{"F", "S", "S", 'S', OrePrefixes.stick.get(Materials.Wood), 'F', new ItemStack(Items.flint, 1)});

--- a/src/main/java/gregtech/common/items/GT_MetaGenerated_Tool_01.java
+++ b/src/main/java/gregtech/common/items/GT_MetaGenerated_Tool_01.java
@@ -1,6 +1,6 @@
 package gregtech.common.items;
 
-import cpw.mods.fml.common.Loader;
+import cpw.mods.fml.common.*;
 import gregtech.api.GregTech_API;
 import gregtech.api.enums.*;
 import gregtech.api.items.GT_MetaGenerated_Tool;

--- a/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
+++ b/src/main/java/gregtech/loaders/postload/GT_MachineRecipeLoader.java
@@ -3452,44 +3452,46 @@ if(Loader.isModLoaded("Railcraft")){
     	GT_Values.RA.addPrimitiveBlastRecipe(Materials.Iron.getBlocks(1), GT_Values.NI, 36, Materials.Steel.getIngots(9), GT_Values.NI, 64800);
     	GT_Values.RA.addPrimitiveBlastRecipe(Materials.Steel.getDust(1), GT_Values.NI, 2, Materials.Steel.getIngots(1), GT_Values.NI, 7200);
     	
-    	GT_Values.RA.addPrimitiveBlastRecipe(Materials.Magnetite.getDust(7), Materials.DarkAsh.getDust(3), 4, Materials.Iron.getIngots(3), GT_Values.NI, 5400);
-    	GT_Values.RA.addPrimitiveBlastRecipe(Materials.Magnetite.getDust(14), Materials.Coal.getDust(3), 4, Materials.Iron.getIngots(6), GT_Values.NI, 10800);
-    	GT_Values.RA.addPrimitiveBlastRecipe(Materials.Magnetite.getDust(14), Materials.Coal.getGems(3), 4, Materials.Iron.getIngots(6), GT_Values.NI, 10800);
-    	if (Loader.isModLoaded("Railcraft")) { 
-    		GT_Values.RA.addPrimitiveBlastRecipe(Materials.Magnetite.getDust(14), RailcraftToolItems.getCoalCoke(3), 4, Materials.Iron.getIngots(6), GT_Values.NI, 7200);
-    	}
-    	GT_Values.RA.addPrimitiveBlastRecipe(Materials.Magnetite.getDust(14), Materials.Carbon.getDust(3), 4, Materials.Iron.getIngots(6), GT_Values.NI, 7200);
-    	GT_Values.RA.addPrimitiveBlastRecipe(Materials.Magnetite.getDust(14), Materials.Carbon.getIngots(3), 4, Materials.Iron.getIngots(6), GT_Values.NI, 7200);
-		
-		GT_Values.RA.addPrimitiveBlastRecipe(Materials.YellowLimonite.getDust(8), Materials.Carbon.getDust(1), 4, Materials.Iron.getIngots(2), GT_Values.NI, 7200);
-    	GT_Values.RA.addPrimitiveBlastRecipe(Materials.YellowLimonite.getDust(8), Materials.Carbon.getIngots(1), 4, Materials.Iron.getIngots(2), GT_Values.NI, 7200);	
-    	GT_Values.RA.addPrimitiveBlastRecipe(Materials.YellowLimonite.getDust(4), Materials.DarkAsh.getDust(1), 2, Materials.Iron.getIngots(1), GT_Values.NI, 5400);
-		GT_Values.RA.addPrimitiveBlastRecipe(Materials.YellowLimonite.getDust(4), Materials.Coal.getDust(1), 2, Materials.Iron.getIngots(1), GT_Values.NI, 7200);
-		GT_Values.RA.addPrimitiveBlastRecipe(Materials.YellowLimonite.getDust(4), Materials.Coal.getGems(1), 2, Materials.Iron.getIngots(1), GT_Values.NI, 7200);
-		if (Loader.isModLoaded("Railcraft")) { 
-			GT_Values.RA.addPrimitiveBlastRecipe(Materials.YellowLimonite.getDust(4), RailcraftToolItems.getCoalCoke(1), 2, Materials.Iron.getIngots(1), GT_Values.NI, 5400);
-		}
-    	
-		GT_Values.RA.addPrimitiveBlastRecipe(Materials.BrownLimonite.getDust(8), Materials.Carbon.getDust(1), 4, Materials.Iron.getIngots(2), GT_Values.NI, 7200);
-    	GT_Values.RA.addPrimitiveBlastRecipe(Materials.BrownLimonite.getDust(8), Materials.Carbon.getIngots(1), 4, Materials.Iron.getIngots(2), GT_Values.NI, 7200);	
-    	GT_Values.RA.addPrimitiveBlastRecipe(Materials.BrownLimonite.getDust(4), Materials.DarkAsh.getDust(1), 2, Materials.Iron.getIngots(1), GT_Values.NI, 5400);
-		GT_Values.RA.addPrimitiveBlastRecipe(Materials.BrownLimonite.getDust(4), Materials.Coal.getDust(1), 2, Materials.Iron.getIngots(1), GT_Values.NI, 7200);
-		GT_Values.RA.addPrimitiveBlastRecipe(Materials.BrownLimonite.getDust(4), Materials.Coal.getGems(1), 2, Materials.Iron.getIngots(1), GT_Values.NI, 7200);
-		if (Loader.isModLoaded("Railcraft")) { 
-			GT_Values.RA.addPrimitiveBlastRecipe(Materials.BrownLimonite.getDust(4), RailcraftToolItems.getCoalCoke(1), 2, Materials.Iron.getIngots(1), GT_Values.NI, 5400);
-		}
-		
-		// Work around for having only 3 slots in the Primitive Blast Furnace
-		if (GT_Mod.gregtechproxy.mUseBandedIronAsHematiteCalcite) {
-			GT_Values.RA.addPrimitiveBlastRecipe(Materials.BandedIron.getDust(10), Materials.Carbon.getDust(1), 4, Materials.Iron.getIngots(4), GT_Values.NI, 7200);
-	    	GT_Values.RA.addPrimitiveBlastRecipe(Materials.BandedIron.getDust(10), Materials.Carbon.getIngots(1), 4, Materials.Iron.getIngots(4), GT_Values.NI, 7200);	
-	    	GT_Values.RA.addPrimitiveBlastRecipe(Materials.BandedIron.getDust(5), Materials.DarkAsh.getDust(1), 2, Materials.Iron.getIngots(2), GT_Values.NI, 5400);
-			GT_Values.RA.addPrimitiveBlastRecipe(Materials.BandedIron.getDust(5), Materials.Coal.getDust(1), 2, Materials.Iron.getIngots(2), GT_Values.NI, 7200);
-			GT_Values.RA.addPrimitiveBlastRecipe(Materials.BandedIron.getDust(5), Materials.Coal.getGems(1), 2, Materials.Iron.getIngots(2), GT_Values.NI, 7200);
+    	if (GT_Mod.gregtechproxy.mBlastFurnaceIronRecipes) {
+	    	GT_Values.RA.addPrimitiveBlastRecipe(Materials.Magnetite.getDust(7), Materials.DarkAsh.getDust(3), 4, Materials.Iron.getIngots(3), GT_Values.NI, 5400);
+	    	GT_Values.RA.addPrimitiveBlastRecipe(Materials.Magnetite.getDust(14), Materials.Coal.getDust(3), 4, Materials.Iron.getIngots(6), GT_Values.NI, 10800);
+	    	GT_Values.RA.addPrimitiveBlastRecipe(Materials.Magnetite.getDust(14), Materials.Coal.getGems(3), 4, Materials.Iron.getIngots(6), GT_Values.NI, 10800);
+	    	if (Loader.isModLoaded("Railcraft")) { 
+	    		GT_Values.RA.addPrimitiveBlastRecipe(Materials.Magnetite.getDust(14), RailcraftToolItems.getCoalCoke(3), 4, Materials.Iron.getIngots(6), GT_Values.NI, 7200);
+	    	}
+	    	GT_Values.RA.addPrimitiveBlastRecipe(Materials.Magnetite.getDust(14), Materials.Carbon.getDust(3), 4, Materials.Iron.getIngots(6), GT_Values.NI, 7200);
+	    	GT_Values.RA.addPrimitiveBlastRecipe(Materials.Magnetite.getDust(14), Materials.Carbon.getIngots(3), 4, Materials.Iron.getIngots(6), GT_Values.NI, 7200);
+			
+			GT_Values.RA.addPrimitiveBlastRecipe(Materials.YellowLimonite.getDust(8), Materials.Carbon.getDust(1), 4, Materials.Iron.getIngots(2), GT_Values.NI, 7200);
+	    	GT_Values.RA.addPrimitiveBlastRecipe(Materials.YellowLimonite.getDust(8), Materials.Carbon.getIngots(1), 4, Materials.Iron.getIngots(2), GT_Values.NI, 7200);	
+	    	GT_Values.RA.addPrimitiveBlastRecipe(Materials.YellowLimonite.getDust(4), Materials.DarkAsh.getDust(1), 2, Materials.Iron.getIngots(1), GT_Values.NI, 5400);
+			GT_Values.RA.addPrimitiveBlastRecipe(Materials.YellowLimonite.getDust(4), Materials.Coal.getDust(1), 2, Materials.Iron.getIngots(1), GT_Values.NI, 7200);
+			GT_Values.RA.addPrimitiveBlastRecipe(Materials.YellowLimonite.getDust(4), Materials.Coal.getGems(1), 2, Materials.Iron.getIngots(1), GT_Values.NI, 7200);
 			if (Loader.isModLoaded("Railcraft")) { 
-				GT_Values.RA.addPrimitiveBlastRecipe(Materials.BandedIron.getDust(5), RailcraftToolItems.getCoalCoke(1), 2, Materials.Iron.getIngots(2), GT_Values.NI, 5400);
+				GT_Values.RA.addPrimitiveBlastRecipe(Materials.YellowLimonite.getDust(4), RailcraftToolItems.getCoalCoke(1), 2, Materials.Iron.getIngots(1), GT_Values.NI, 5400);
 			}
-	 	}
+	    	
+			GT_Values.RA.addPrimitiveBlastRecipe(Materials.BrownLimonite.getDust(8), Materials.Carbon.getDust(1), 4, Materials.Iron.getIngots(2), GT_Values.NI, 7200);
+	    	GT_Values.RA.addPrimitiveBlastRecipe(Materials.BrownLimonite.getDust(8), Materials.Carbon.getIngots(1), 4, Materials.Iron.getIngots(2), GT_Values.NI, 7200);	
+	    	GT_Values.RA.addPrimitiveBlastRecipe(Materials.BrownLimonite.getDust(4), Materials.DarkAsh.getDust(1), 2, Materials.Iron.getIngots(1), GT_Values.NI, 5400);
+			GT_Values.RA.addPrimitiveBlastRecipe(Materials.BrownLimonite.getDust(4), Materials.Coal.getDust(1), 2, Materials.Iron.getIngots(1), GT_Values.NI, 7200);
+			GT_Values.RA.addPrimitiveBlastRecipe(Materials.BrownLimonite.getDust(4), Materials.Coal.getGems(1), 2, Materials.Iron.getIngots(1), GT_Values.NI, 7200);
+			if (Loader.isModLoaded("Railcraft")) { 
+				GT_Values.RA.addPrimitiveBlastRecipe(Materials.BrownLimonite.getDust(4), RailcraftToolItems.getCoalCoke(1), 2, Materials.Iron.getIngots(1), GT_Values.NI, 5400);
+			}
+			
+			// Work around for having only 3 slots in the Primitive Blast Furnace
+			if (GT_Mod.gregtechproxy.mUseBandedIronAsHematiteCalcite) {
+				GT_Values.RA.addPrimitiveBlastRecipe(Materials.BandedIron.getDust(10), Materials.Carbon.getDust(1), 4, Materials.Iron.getIngots(4), GT_Values.NI, 7200);
+		    	GT_Values.RA.addPrimitiveBlastRecipe(Materials.BandedIron.getDust(10), Materials.Carbon.getIngots(1), 4, Materials.Iron.getIngots(4), GT_Values.NI, 7200);	
+		    	GT_Values.RA.addPrimitiveBlastRecipe(Materials.BandedIron.getDust(5), Materials.DarkAsh.getDust(1), 2, Materials.Iron.getIngots(2), GT_Values.NI, 5400);
+				GT_Values.RA.addPrimitiveBlastRecipe(Materials.BandedIron.getDust(5), Materials.Coal.getDust(1), 2, Materials.Iron.getIngots(2), GT_Values.NI, 7200);
+				GT_Values.RA.addPrimitiveBlastRecipe(Materials.BandedIron.getDust(5), Materials.Coal.getGems(1), 2, Materials.Iron.getIngots(2), GT_Values.NI, 7200);
+				if (Loader.isModLoaded("Railcraft")) { 
+					GT_Values.RA.addPrimitiveBlastRecipe(Materials.BandedIron.getDust(5), RailcraftToolItems.getCoalCoke(1), 2, Materials.Iron.getIngots(2), GT_Values.NI, 5400);
+				}
+		 	}
+    	}
     	    	
 		GT_Values.RA.addPrimitiveBlastRecipe(Materials.Malachite.getDust(5), Materials.Carbon.getDust(1), 4, Materials.Copper.getIngots(1), GT_Values.NI, 7200);
     	GT_Values.RA.addPrimitiveBlastRecipe(Materials.Malachite.getDust(5), Materials.Carbon.getIngots(1), 4, Materials.Copper.getIngots(1), GT_Values.NI, 7200);	

--- a/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
+++ b/src/main/java/gregtech/loaders/preload/GT_Loader_MetaTileEntities.java
@@ -403,19 +403,24 @@ public class GT_Loader_MetaTileEntities implements Runnable {
         ItemList.Machine_Steel_Boiler_Lava.set(new GT_MetaTileEntity_Boiler_Lava(102, "boiler.lava", "High Pressure Lava Boiler").getStackForm(1L));
         ItemList.Machine_Bronze_Boiler_Solar.set(new GT_MetaTileEntity_Boiler_Solar(105, "boiler.solar", "Simple Solar Boiler").getStackForm(1L));
 
-        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Bronze_Boiler.get(1L, new Object[0]), bits, new Object[]{aTextPlate, "P P", "BFB", 'F', OreDictNames.craftingFurnace, 'P', OrePrefixes.plate.get(Materials.Bronze), 'B', new ItemStack(Blocks.brick_block, 1)});
-        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Steel_Boiler.get(1L, new Object[0]), bits, new Object[]{aTextPlate, "P P", "BFB", 'F', OreDictNames.craftingFurnace, 'P', OrePrefixes.plate.get(Materials.Steel), 'B', new ItemStack(Blocks.brick_block, 1)});
-        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Steel_Boiler_Lava.get(1L, new Object[0]), bits, new Object[]{aTextPlate, "GGG", aTextPlateMotor, 'M', ItemList.Hull_Steel_Bricks, 'P', OrePrefixes.plate.get(Materials.Steel), 'G', new ItemStack(Blocks.glass, 1)});
-        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Bronze_Boiler_Solar.get(1L, new Object[0]), bits, new Object[]{"GGG", "SSS", aTextPlateMotor, 'M', ItemList.Hull_Bronze_Bricks, 'P', OrePrefixes.pipeSmall.get(Materials.Bronze), 'S', OrePrefixes.plate.get(Materials.Silver), 'G', new ItemStack(Blocks.glass, 1)});
-
+        // Disable steam machines if GT6 is detected
+        if (!Loader.isModLoaded("gregtech")) {
+	        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Bronze_Boiler.get(1L, new Object[0]), bits, new Object[]{aTextPlate, "P P", "BFB", 'F', OreDictNames.craftingFurnace, 'P', OrePrefixes.plate.get(Materials.Bronze), 'B', new ItemStack(Blocks.brick_block, 1)});
+	        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Steel_Boiler.get(1L, new Object[0]), bits, new Object[]{aTextPlate, "P P", "BFB", 'F', OreDictNames.craftingFurnace, 'P', OrePrefixes.plate.get(Materials.Steel), 'B', new ItemStack(Blocks.brick_block, 1)});
+	        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Steel_Boiler_Lava.get(1L, new Object[0]), bits, new Object[]{aTextPlate, "GGG", aTextPlateMotor, 'M', ItemList.Hull_Steel_Bricks, 'P', OrePrefixes.plate.get(Materials.Steel), 'G', new ItemStack(Blocks.glass, 1)});
+	        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Bronze_Boiler_Solar.get(1L, new Object[0]), bits, new Object[]{"GGG", "SSS", aTextPlateMotor, 'M', ItemList.Hull_Bronze_Bricks, 'P', OrePrefixes.pipeSmall.get(Materials.Bronze), 'S', OrePrefixes.plate.get(Materials.Silver), 'G', new ItemStack(Blocks.glass, 1)});
+        }
+        
         ItemList.Machine_Bronze_BlastFurnace.set(new GT_MetaTileEntity_BronzeBlastFurnace(108, "bronzemachine.blastfurnace", "Bronze Plated Blast Furnace").getStackForm(1L));
         if (!Loader.isModLoaded("terrafirmacraft")) {
             GT_ModHandler.addCraftingRecipe(ItemList.Machine_Bronze_BlastFurnace.get(1L, new Object[0]), bits, new Object[]{"PFP", "FwF", "PFP", 'P', OrePrefixes.plate.get(Materials.Bronze), 'F', OreDictNames.craftingFurnace});
         }
 
         ItemList.Machine_Bricked_BlastFurnace.set(new GT_MetaTileEntity_BrickedBlastFurnace(130, "multimachine.brickedblastfurnace", "Bricked Blast Furnace").getStackForm(1L));
+        // Add WroughtIron recipe
         if (GT_Mod.gregtechproxy.mBrickedBlastFurnace) {
         	GT_ModHandler.addCraftingRecipe(ItemList.Machine_Bricked_BlastFurnace.get(1L, new Object[0]), GT_ModHandler.RecipeBits.NOT_REMOVABLE | GT_ModHandler.RecipeBits.BUFFERED, new Object[]{"BBB", "BPB", "BBB", 'B', ItemList.Firebrick, 'P', Materials.Iron.getPlates(1)});
+        	GT_ModHandler.addCraftingRecipe(ItemList.Machine_Bricked_BlastFurnace.get(1L, new Object[0]), GT_ModHandler.RecipeBits.NOT_REMOVABLE | GT_ModHandler.RecipeBits.BUFFERED, new Object[]{"BBB", "BPB", "BBB", 'B', ItemList.Firebrick, 'P', Materials.WroughtIron.getPlates(1)});
         }
         
         ItemList.Machine_Bronze_Furnace.set(new GT_MetaTileEntity_Furnace_Bronze(103, "bronzemachine.furnace", "Steam Furnace").getStackForm(1L));
@@ -431,19 +436,21 @@ public class GT_Loader_MetaTileEntities implements Runnable {
         ItemList.Machine_Bronze_AlloySmelter.set(new GT_MetaTileEntity_AlloySmelter_Bronze(118, "bronzemachine.alloysmelter", "Steam Alloy Smelter").getStackForm(1L));
         ItemList.Machine_Steel_AlloySmelter.set(new GT_MetaTileEntity_AlloySmelter_Steel(119, "steelmachine.alloysmelter", "High Pressure Alloy Smelter").getStackForm(1L));
 
-        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Bronze_Furnace.get(1L, new Object[0]), bits, new Object[]{"XXX", "XMX", "XFX", 'M', ItemList.Hull_Bronze_Bricks, 'X', OrePrefixes.pipeSmall.get(Materials.Bronze), 'F', OreDictNames.craftingFurnace});
-        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Steel_Furnace.get(1L, new Object[0]), bits, new Object[]{"XXX", "XMX", "XFX", 'M', ItemList.Hull_Steel_Bricks, 'X', OrePrefixes.pipeSmall.get(Materials.Steel), 'F', OreDictNames.craftingFurnace});
-        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Bronze_Macerator.get(1L, new Object[0]), bits, new Object[]{"DXD", "XMX", "PXP", 'M', ItemList.Hull_Bronze, 'X', OrePrefixes.pipeSmall.get(Materials.Bronze), 'P', OreDictNames.craftingPiston, 'D', OrePrefixes.gem.get(Materials.Diamond)});
-        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Steel_Macerator.get(1L, new Object[0]), bits, new Object[]{"DXD", "XMX", "PXP", 'M', ItemList.Hull_Steel, 'X', OrePrefixes.pipeSmall.get(Materials.Steel), 'P', OreDictNames.craftingPiston, 'D', OrePrefixes.gem.get(Materials.Diamond)});
-        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Bronze_Extractor.get(1L, new Object[0]), bits, new Object[]{"XXX", "PMG", "XXX", 'M', ItemList.Hull_Bronze, 'X', OrePrefixes.pipeSmall.get(Materials.Bronze), 'P', OreDictNames.craftingPiston, 'G', new ItemStack(Blocks.glass, 1)});
-        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Steel_Extractor.get(1L, new Object[0]), bits, new Object[]{"XXX", "PMG", "XXX", 'M', ItemList.Hull_Steel, 'X', OrePrefixes.pipeSmall.get(Materials.Steel), 'P', OreDictNames.craftingPiston, 'G', new ItemStack(Blocks.glass, 1)});
-        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Bronze_Hammer.get(1L, new Object[0]), bits, new Object[]{"XPX", "XMX", "XAX", 'M', ItemList.Hull_Bronze, 'X', OrePrefixes.pipeSmall.get(Materials.Bronze), 'P', OreDictNames.craftingPiston, 'A', OreDictNames.craftingAnvil});
-        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Steel_Hammer.get(1L, new Object[0]), bits, new Object[]{"XPX", "XMX", "XAX", 'M', ItemList.Hull_Steel, 'X', OrePrefixes.pipeSmall.get(Materials.Steel), 'P', OreDictNames.craftingPiston, 'A', OreDictNames.craftingAnvil});
-        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Bronze_Compressor.get(1L, new Object[0]), bits, new Object[]{"XXX", aTextPlateMotor, "XXX", 'M', ItemList.Hull_Bronze, 'X', OrePrefixes.pipeSmall.get(Materials.Bronze), 'P', OreDictNames.craftingPiston});
-        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Steel_Compressor.get(1L, new Object[0]), bits, new Object[]{"XXX", aTextPlateMotor, "XXX", 'M', ItemList.Hull_Steel, 'X', OrePrefixes.pipeSmall.get(Materials.Steel), 'P', OreDictNames.craftingPiston});
-        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Bronze_AlloySmelter.get(1L, new Object[0]), bits, new Object[]{"XXX", "FMF", "XXX", 'M', ItemList.Hull_Bronze_Bricks, 'X', OrePrefixes.pipeSmall.get(Materials.Bronze), 'F', OreDictNames.craftingFurnace});
-        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Steel_AlloySmelter.get(1L, new Object[0]), bits, new Object[]{"XXX", "FMF", "XXX", 'M', ItemList.Hull_Steel_Bricks, 'X', OrePrefixes.pipeSmall.get(Materials.Steel), 'F', OreDictNames.craftingFurnace});
-
+        // Disable steam machines if GT6 is detected
+        if (!Loader.isModLoaded("gregtech")) {
+	        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Bronze_Furnace.get(1L, new Object[0]), bits, new Object[]{"XXX", "XMX", "XFX", 'M', ItemList.Hull_Bronze_Bricks, 'X', OrePrefixes.pipeSmall.get(Materials.Bronze), 'F', OreDictNames.craftingFurnace});
+	        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Steel_Furnace.get(1L, new Object[0]), bits, new Object[]{"XXX", "XMX", "XFX", 'M', ItemList.Hull_Steel_Bricks, 'X', OrePrefixes.pipeSmall.get(Materials.Steel), 'F', OreDictNames.craftingFurnace});
+	        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Bronze_Macerator.get(1L, new Object[0]), bits, new Object[]{"DXD", "XMX", "PXP", 'M', ItemList.Hull_Bronze, 'X', OrePrefixes.pipeSmall.get(Materials.Bronze), 'P', OreDictNames.craftingPiston, 'D', OrePrefixes.gem.get(Materials.Diamond)});
+	        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Steel_Macerator.get(1L, new Object[0]), bits, new Object[]{"DXD", "XMX", "PXP", 'M', ItemList.Hull_Steel, 'X', OrePrefixes.pipeSmall.get(Materials.Steel), 'P', OreDictNames.craftingPiston, 'D', OrePrefixes.gem.get(Materials.Diamond)});
+	        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Bronze_Extractor.get(1L, new Object[0]), bits, new Object[]{"XXX", "PMG", "XXX", 'M', ItemList.Hull_Bronze, 'X', OrePrefixes.pipeSmall.get(Materials.Bronze), 'P', OreDictNames.craftingPiston, 'G', new ItemStack(Blocks.glass, 1)});
+	        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Steel_Extractor.get(1L, new Object[0]), bits, new Object[]{"XXX", "PMG", "XXX", 'M', ItemList.Hull_Steel, 'X', OrePrefixes.pipeSmall.get(Materials.Steel), 'P', OreDictNames.craftingPiston, 'G', new ItemStack(Blocks.glass, 1)});
+	        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Bronze_Hammer.get(1L, new Object[0]), bits, new Object[]{"XPX", "XMX", "XAX", 'M', ItemList.Hull_Bronze, 'X', OrePrefixes.pipeSmall.get(Materials.Bronze), 'P', OreDictNames.craftingPiston, 'A', OreDictNames.craftingAnvil});
+	        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Steel_Hammer.get(1L, new Object[0]), bits, new Object[]{"XPX", "XMX", "XAX", 'M', ItemList.Hull_Steel, 'X', OrePrefixes.pipeSmall.get(Materials.Steel), 'P', OreDictNames.craftingPiston, 'A', OreDictNames.craftingAnvil});
+	        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Bronze_Compressor.get(1L, new Object[0]), bits, new Object[]{"XXX", aTextPlateMotor, "XXX", 'M', ItemList.Hull_Bronze, 'X', OrePrefixes.pipeSmall.get(Materials.Bronze), 'P', OreDictNames.craftingPiston});
+	        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Steel_Compressor.get(1L, new Object[0]), bits, new Object[]{"XXX", aTextPlateMotor, "XXX", 'M', ItemList.Hull_Steel, 'X', OrePrefixes.pipeSmall.get(Materials.Steel), 'P', OreDictNames.craftingPiston});
+	        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Bronze_AlloySmelter.get(1L, new Object[0]), bits, new Object[]{"XXX", "FMF", "XXX", 'M', ItemList.Hull_Bronze_Bricks, 'X', OrePrefixes.pipeSmall.get(Materials.Bronze), 'F', OreDictNames.craftingFurnace});
+	        GT_ModHandler.addCraftingRecipe(ItemList.Machine_Steel_AlloySmelter.get(1L, new Object[0]), bits, new Object[]{"XXX", "FMF", "XXX", 'M', ItemList.Hull_Steel_Bricks, 'X', OrePrefixes.pipeSmall.get(Materials.Steel), 'F', OreDictNames.craftingFurnace});
+        }
 
         ItemList.Locker_ULV.set(new GT_MetaTileEntity_Locker(150, "locker.tier.00", "Ultra Low Voltage Locker", 0).getStackForm(1L));
         ItemList.Locker_LV.set(new GT_MetaTileEntity_Locker(151, "locker.tier.01", "Low Voltage Locker", 1).getStackForm(1L));


### PR DESCRIPTION
Fixes issue where a trying to create a GT6 flint shovel resulted in a GT5 knife.  GT5 knife does not cut grass so this resolves the need for a useless tool in ToTG pack.